### PR TITLE
chore: add source URL to extension yaml

### DIFF
--- a/extension.yaml
+++ b/extension.yaml
@@ -7,6 +7,8 @@ license: Apache-2.0
 
 displayName: Firestore Bundle Builder
 
+sourceUrl: https://github.com/firebase/firestore-bundle-builder
+
 description: >-
   Caches publicly available documents in Cloud Firestore data bundles that are served from either Firebase Hosting CDN or from Firebase storage
 


### PR DESCRIPTION
Enabled a URL to be displayed to the source code on extensions.dev