### PR TITLE
Fix: Add input validation for parameterized Firestore paths

### DIFF
--- a/functions/__tests__/bundle.test.ts
+++ b/functions/__tests__/bundle.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { buildQuery } from "../src/build_bundle";
+import { buildQuery, parameterizePath } from "../src/build_bundle";
 import * as admin from "firebase-admin";
 
 describe("buildQuery", () => {
@@ -159,3 +159,25 @@ describe("buildQuery", () => {
     }
   });
 });
+
+describe("parameterizePath", () => {
+  it("should successfully parameterize valid single-segment values", () => {
+    const res = parameterizePath(
+      "stores/$city/products",
+      { city: { type: "string", required: true } },
+      { city: "austin" }
+    );
+    expect(res).toEqual("stores/austin/products");
+  });
+
+  it("should throw an error when parameter values contain forward slashes", () => {
+    expect(() =>
+      parameterizePath(
+        "stores/$city/products",
+        { city: { type: "string", required: true } },
+        { city: "austin/private/salaries" }
+      )
+    ).toThrow("Invalid path segment parameter: cannot contain '/'");
+  });
+});
+

--- a/functions/src/build_bundle.ts
+++ b/functions/src/build_bundle.ts
@@ -120,7 +120,15 @@ export function parameterizePath(
 ): string {
   return path
     .split("/")
-    .map((part) => parameterize(part, params, paramValues))
+    .map((part) => {
+      const resolved = parameterize(part, params, paramValues);
+      if (String(resolved).includes("/")) {
+        throw new Error(
+          `Invalid path segment parameter: cannot contain '/'`
+        );
+      }
+      return resolved;
+    })
     .join("/");
 }
 

--- a/functions/src/build_bundle.ts
+++ b/functions/src/build_bundle.ts
@@ -122,9 +122,9 @@ export function parameterizePath(
     .split("/")
     .map((part) => {
       const resolved = parameterize(part, params, paramValues);
-      if (String(resolved).includes("/")) {
+      if (typeof resolved === "string" && resolved.includes("/")) {
         throw new Error(
-          `Invalid path segment parameter: cannot contain '/'`
+          "Invalid path segment parameter: cannot contain '/'"
         );
       }
       return resolved;


### PR DESCRIPTION
### Fix: Add input validation for parameterized Firestore paths

#### Why
In Cloud Firestore, collection names and document IDs natively prohibit forward slashes (`/`). When developers configure dynamic bundle templates (e.g., `stores/$storeId/menu`), path parameters are designed to represent simple, single-segment identifiers. Currently, `parameterizePath()` performs raw string substitution without validating whether incoming inputs adhere to Firestore's segment naming structures. Allowing unvalidated character sequences in path variables can produce malformed reference paths and unintended database behaviors.

#### What
* Added input validation exclusively to structural path substitutions inside `parameterizePath()`.
* If a parameter substituted into a document or collection path contains a `/`, the extension immediately stops execution and throws a clear validation error.
* Confined this check to path construction only, ensuring query filtering conditions (`handleCondition`) continue to allow unrestricted string comparisons (e.g., `.where("type", "==", "Dark/Medium Roast")`).

#### Customer Impact
* **Zero Breaking Changes:** Because forward slashes are forbidden in standard Firestore Document IDs and Collection names, valid developer configurations and legitimate application traffic remain completely unaffected. No configuration changes or migrations are required.
* **Improved System Robustness:** Ensures bundle generation strictly adheres to the developer's designed data hierarchy and prevents malformed reference paths from executing against the database.
* **Better Developer Experience:** App developers passing incorrectly formatted variables in URLs now receive clear, immediate diagnostic errors instead of downstream query failures.
