### PR TITLE
Release: Bump version to 0.1.5 and harden parameter validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.1.5
+
+Added input validation for parameterized paths to enforce segment integrity.
+
 ## Version 0.1.4
 
 Republish to stabilize extension.

--- a/extension.yaml
+++ b/extension.yaml
@@ -16,7 +16,7 @@
 
 name: firestore-bundle-builder
 specVersion: v1beta
-version: 0.1.4
+version: 0.1.5
 license: Apache-2.0
 
 displayName: Firestore Bundle Builder

--- a/functions/src/build_bundle.ts
+++ b/functions/src/build_bundle.ts
@@ -122,7 +122,7 @@ export function parameterizePath(
     .split("/")
     .map((part) => {
       const resolved = parameterize(part, params, paramValues);
-      if (String(resolved).includes("/")) {
+      if (resolved != null && String(resolved).includes("/")) {
         throw new Error(
           `Invalid path segment parameter: cannot contain '/'`
         );

--- a/functions/src/build_bundle.ts
+++ b/functions/src/build_bundle.ts
@@ -122,9 +122,9 @@ export function parameterizePath(
     .split("/")
     .map((part) => {
       const resolved = parameterize(part, params, paramValues);
-      if (typeof resolved === "string" && resolved.includes("/")) {
+      if (String(resolved).includes("/")) {
         throw new Error(
-          "Invalid path segment parameter: cannot contain '/'"
+          `Invalid path segment parameter: cannot contain '/'`
         );
       }
       return resolved;


### PR DESCRIPTION
Bumps extension version to 0.1.5, regenerates README documentation, and replaces type-constrained string check with robust `String(resolved)` validation to prevent array/object query parameter bypasses.